### PR TITLE
Framework E (17.104.x): Java 21 / WildFly 32 / Jakarta EE 10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Enable gitleaks PR scan
 - Enable repo public visibility
+
+## [21.0.0-SNAPSHOT] - 2026-04-20
+### Security
+- Bumped `json-smart.version` from `2.4.9` to `2.5.2` — fixes CVE-2023-1370 (uncontrolled recursion / stack overflow DoS, CVSS 7.5)
+- Bumped `apache.pdfbox.version` from `2.0.24` to `2.0.36` — fixes CVE-2022-27944 (infinite loop DoS on crafted PDF, fixed in 2.0.26) and subsequent 2.x patch CVEs; `pdfbox-tools` and `fontbox` updated in lockstep
+- Bumped `poi.ooxml.version` from `5.2.2` to `5.4.1` — fixes CVE-2025-31672 (uncontrolled resource consumption on crafted Office files, affects < 5.4.0)
+- Bumped `quartz.version` from `2.3.2` to `2.5.0` — fixes CVE-2023-39017 (code injection via JMS job data deserialization, CVSS 9.8)
+
+## [21.0.0-SNAPSHOT] - 2026-04-14
+### Changed
+- Bumped version to `21.0.0-SNAPSHOT` for Java 21 / WildFly 34 migration
+- Updated parent `cpp-platform-maven-parent-pom` to `21.0.0-SNAPSHOT`
+- Updated imported `cp-framework-common-bom` to `21.0.0-SNAPSHOT`
+- Removed obsolete `jboss-javaee-7.0` BOM import (conflicted with Jakarta EE 10)
+- Replaced `javax:javaee-api` managed dependency with `jakarta.platform:jakarta.jakartaee-api:10.0.0`; retained `javax:javaee-api:8.0.1` entry for legacy backward compatibility
+- `weld-core-version`: `1.1.8.Final` → `3.1.9.Final`
+- `guava.version`: `32.1.3-jre` → `33.5.0-jre`
+- `org.everit.json.schema.version`: `1.3.0` → `1.6.0`
+- `mvel2.version`: `2.4.13.Final` → `2.5.2.Final`
+- `jboss.resteasy.version`: `4.3.0.Final` → `6.2.15.Final`
+- Added `com.github.tomakehurst:wiremock:2.35.2` managed dependency (new framework BOM moved to `org.wiremock:wiremock` 3.x; platform projects still use the 2.x groupId)
+
+## [17.104.0-M2] - 2025-07-24
 ### Security
 - Update Commons Fileupload version to **1.6.0** to fix **security vulnerability CVE-2025-48976**
   Detail: https://cwe.mitre.org/data/definitions/770.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# cpp-platform-maven-common-bom
+
+`uk.gov.moj.cpp.common:common-bom`
+
+The CPP platform dependency bill of materials. It extends the framework-tier `maven-common-bom` with additional library versions specific to the platform and bounded-context tier, covering domain-specific frameworks (Activiti), additional Apache Commons modules, document processing, SOAP/CXF, and CPP-specific library versions.
+
+## Position in the hierarchy
+
+```
+cpp-platform-maven-parent-pom
+└── cpp-platform-maven-common-bom  ← this project
+```
+
+This BOM is imported by `cpp-platform-maven-service-parent-pom` and `cpp-platform-libraries`, making all versions available to every `cpp-context-*` service.
+
+## Maven coordinates
+
+| Property | Value |
+|---|---|
+| `groupId` | `uk.gov.moj.cpp.common` |
+| `artifactId` | `common-bom` |
+| Parent | `uk.gov.moj.cpp.common:parent-pom` |
+
+## What this BOM adds
+
+This BOM imports `maven-common-bom` (`uk.gov.justice:maven-common-bom`) so that all framework-tier versions are also available here. It then adds platform-specific versions:
+
+**Workflow**
+- Activiti 5.22.0
+
+**Messaging**
+- Apache ActiveMQ Classic client 5.16.8, RA 5.17.2 (legacy broker support)
+
+**Additional Apache Commons**
+- commons-dbutils 1.7, commons-pool2 2.13.0, commons-compress 1.26.0, commons-csv 1.4, commons-fileupload 1.6.0, commons-net 3.9.0, commons-text 1.10.0
+
+**Web services**
+- Apache CXF 3.4.4
+
+**Document processing**
+- Apache PDFBox 2.0.36
+- Apache POI (OOXML) 5.4.1 — Excel/Word document generation
+
+**MOJ interface JARs** — versioned dependencies on shared MOJ service API JARs (assignment, usersgroups, progression, hearing, SJP, referencedata). The `enforce-moj-latest-interfaces` enforcer rule requires these to be at their latest released versions.
+
+## Usage
+
+Import in your project's `<dependencyManagement>`:
+
+```xml
+<dependency>
+    <groupId>uk.gov.moj.cpp.common</groupId>
+    <artifactId>common-bom</artifactId>
+    <version>${cpp.common-bom.version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+</dependency>
+```
+
+All projects that inherit from `cpp-platform-maven-service-parent-pom` get this import automatically.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j21
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:common-bom"

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-bom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CPP Common BOM</name>
     <description>Common bill of materials defining standard versions for dependencies</description>
@@ -29,7 +29,7 @@
             Imported here to avoid duplication of library versions.
             File can be found here: https://github.com/hmcts/cp-maven-common-bom
         -->
-        <framework-comon-bom.version>21.0.0-SNAPSHOT</framework-comon-bom.version>
+        <framework-comon-bom.version>21.0.0-M1-SNAPSHOT</framework-comon-bom.version>
 
         <!-- ===== Activiti ===== -->
         <activiti.version>5.22.0</activiti.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>17.10.12</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-bom</artifactId>
-    <version>17.104.1-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CPP Common BOM</name>
     <description>Common bill of materials defining standard versions for dependencies</description>
@@ -24,118 +24,147 @@
 
     <properties>
         <cpp.scm.project>cpp.platform.maven.common-bom</cpp.scm.project>
-
         <!--
             Version of the common bom file of the framework code.
-            Imported here to avoid duplication of library versions
-            File can be found here:
-            https://github.com/hmcts/cp-maven-common-bom
+            Imported here to avoid duplication of library versions.
+            File can be found here: https://github.com/hmcts/cp-maven-common-bom
         -->
-        <framework-comon-bom.version>17.104.0</framework-comon-bom.version>
-        <docmosis.repackaging.version>17.10.2</docmosis.repackaging.version>
+        <framework-comon-bom.version>21.0.0-SNAPSHOT</framework-comon-bom.version>
 
-        <weld-ee-version>1.0.0.CR8</weld-ee-version>
-        <weld-core-version>1.1.8.Final</weld-core-version>
+        <!-- ===== Activiti ===== -->
+        <activiti.version>5.22.0</activiti.version>
+
+        <!-- ===== Apache ActiveMQ (classic) ===== -->
+        <activemq-client.version>5.16.8</activemq-client.version>
+        <activemq-ra.version>5.17.2</activemq-ra.version>
+
+        <!-- ===== Apache Commons ===== -->
+        <commons-dbutils.version>1.7</commons-dbutils.version>
+        <commons-pool2.version>2.13.0</commons-pool2.version>
         <commons.compress.version>1.26.0</commons.compress.version>
         <commons.csv.version>1.4</commons.csv.version>
-        <commons-dbutils.version>1.7</commons-dbutils.version>
         <commons.digester.version>1.8.1</commons.digester.version>
         <commons.discovery.version>0.5</commons.discovery.version>
         <commons.fileupload.version>1.6.0</commons.fileupload.version>
         <commons.net.version>3.9.0</commons.net.version>
-        <commons-pool2.version>2.9.0</commons-pool2.version>
         <commons.text.version>1.10.0</commons.text.version>
 
-        <javax.activation.version>1.1.1</javax.activation.version>
-        <javax.transaction.version>1.1</javax.transaction.version>
-        <javax.jms.version>2.0</javax.jms.version>
-        <jsp.version>2.2</jsp.version>
-        <hibernate-types.version>2.20.0</hibernate-types.version>
-        <activemq-ra.version>5.17.2</activemq-ra.version>
-        <net.trajano.commons.commons-testing.version>1.0.1</net.trajano.commons.commons-testing.version>
-        <github.lukehutch.fast-classpath-scanner.version>2.0.8</github.lukehutch.fast-classpath-scanner.version>
-        <hamcrest.optional.version>2.0</hamcrest.optional.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <hamcrest-date.version>2.0.4</hamcrest-date.version>
-        <netty.version>4.1.77.Final</netty.version>
-        <tomcat.version>8.0.21</tomcat.version>
-        <camel.version>2.16.1</camel.version>
-        <gson.version>2.8.9</gson.version>
-        <c3p0.version>4.1.6.Final</c3p0.version>
-        <selenium.version>2.46.0</selenium.version>
+        <!-- ===== Apache CXF ===== -->
+        <cxf.version>3.4.4</cxf.version>
+
+        <!-- ===== Apache PDFBox ===== -->
+        <apache.pdfbox.version>2.0.36</apache.pdfbox.version>
+
+        <!-- ===== Apache POI ===== -->
+        <poi.ooxml.version>5.4.1</poi.ooxml.version>
+
+        <!-- ===== AspectJ ===== -->
         <aspectj.version>1.7.3</aspectj.version>
-        <mongodb-driver-version>3.0.2</mongodb-driver-version>
-        <activiti.version>5.22.0</activiti.version>
-        <saaj-impl.version>1.3.15</saaj-impl.version>
-        <jaxp-ri.version>1.4.5</jaxp-ri.version>
-        <streambuffer.version>2.0.2</streambuffer.version>
-        <greenmail.version>1.6.5</greenmail.version>
-        <org.everit.json.schema.version>1.3.0</org.everit.json.schema.version>
-        <guava.version>32.1.3-jre</guava.version>
-        <activemq-client.version>5.16.8</activemq-client.version>
-        <maven.cucumber.reporting.plugin.version>2.0.0</maven.cucumber.reporting.plugin.version>
 
-        <!-- JBoss dependency versions -->
-        <version.jboss.spec.javaee.7.0>1.0.0.Final</version.jboss.spec.javaee.7.0>
-
-        <drools.version>7.69.0.Final</drools.version>
-        <mvel2.version>2.4.13.Final</mvel2.version>
-        <quartz.version>2.3.2</quartz.version>
-        <mockftp.version>2.6</mockftp.version>
-        <bean.matchers.version>0.10</bean.matchers.version>
-        <docmosis.version>4.7.1</docmosis.version>
-        <apache.pdfbox.version>2.0.24</apache.pdfbox.version>
-        <org.xmlunit.version>2.6.3</org.xmlunit.version>
-        <elasticsearch.version>7.17.23</elasticsearch.version>
-        <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
-        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-
+        <!-- ===== Azure ===== -->
+        <azure-client-authentication.version>1.7.14</azure-client-authentication.version>
         <azure-core.version>1.49.1</azure-core.version>
         <azure-data-appconfiguration.version>1.6.2</azure-data-appconfiguration.version>
-        <azure-client-authentication.version>1.7.14</azure-client-authentication.version>
         <azure-eventgrid.version>1.4.0</azure-eventgrid.version>
-        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
         <azure-identity.version>1.13.0</azure-identity.version>
-        <azure-storage-file-datalake>12.10.1</azure-storage-file-datalake>
-        <azure-storage-blob.version>12.27.0-beta.1</azure-storage-blob.version>
         <azure-resourcemanager.version>2.40.0</azure-resourcemanager.version>
+        <azure-storage-blob.version>12.27.0-beta.1</azure-storage-blob.version>
+        <azure-storage-file-datalake>12.10.1</azure-storage-file-datalake>
+        <azure-storage-version>8.4.0</azure-storage-version>
+        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
 
-        <camunda.junit5.version>1.1.0</camunda.junit5.version>
+        <!-- ===== Camunda ===== -->
         <camunda.version>7.17.0</camunda.version>
-        <camunda.bpm.assert.version>2.0-alpha2</camunda.bpm.assert.version>
-        <cxf.version>3.4.4</cxf.version>
-        <cglib.version>3.3.0</cglib.version>
+
+        <!-- ===== Database / Persistence ===== -->
+        <c3p0.version>4.1.6.Final</c3p0.version>
+        <hibernate-types.version>2.20.0</hibernate-types.version>
+        <mongodb-driver-version>3.0.2</mongodb-driver-version>
+        <quartz.version>2.5.0</quartz.version>
+
+        <!-- ===== Docmosis ===== -->
+        <docmosis.repackaging.version>17.10.2</docmosis.repackaging.version>
+        <docmosis.version>4.7.1</docmosis.version>
+
+        <!-- ===== Document services ===== -->
         <darts-remote.version>1.0</darts-remote.version>
-        <dbunit.version>2.5.1</dbunit.version>
         <dfs-remote.version>6.7.1300.0206</dfs-remote.version>
-        <domain.dsl.test.version>0.3.1</domain.dsl.test.version>
-        <generex.version>1.0.2</generex.version>
+
+        <!-- ===== Drools / Rules Engine ===== -->
+        <drools.version>10.1.0</drools.version>
+        <mvel2.version>2.5.2.Final</mvel2.version>
+
+        <!-- ===== Elasticsearch ===== -->
+        <elasticsearch.version>7.17.23</elasticsearch.version>
+
+        <!-- ===== JAXB / XML / Web Services ===== -->
         <istack-commons-runtime>4.0.1</istack-commons-runtime>
-        <lettuce.core.version>5.2.1.RELEASE</lettuce.core.version>
-        <javax.el-api.version>3.0.0</javax.el-api.version>
-        <javax.jws.api.version>1.1</javax.jws.api.version>
-        <jaxws-api.version>2.2.11</jaxws-api.version>
-        <!-- TODO: move to GitHub -->
-        <jboss.resteasy.version>4.3.0.Final</jboss.resteasy.version>
-        <jaxws.api.version>2.3.1</jaxws.api.version>
+        <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
+        <jaxp-ri.version>1.4.5</jaxp-ri.version>
         <jaxws.rt.version>2.3.4</jaxws.rt.version>
+        <saaj-impl.version>1.3.15</saaj-impl.version>
+        <streambuffer.version>2.0.2</streambuffer.version>
+
+        <!-- ===== JBoss / RESTEasy ===== -->
         <jberet.version>2.2.1.Final</jberet.version>
+        <!-- TODO: move to GitHub -->
+        <jboss.resteasy.version>6.2.15.Final</jboss.resteasy.version>
         <jbossws.cxf.client.version>6.1.0.Final</jbossws.cxf.client.version>
-        <jedis-mock.version>0.1.16</jedis-mock.version>
+
+        <!-- ===== Joda Time ===== -->
         <joda-time.version>2.10</joda-time.version>
+
+        <!-- ===== JSON utilities ===== -->
+        <gson.version>2.8.9</gson.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <json.version>2.12.3</json.version>
-        <json-smart.version>2.4.9</json-smart.version>
-        <jsr181-api.version>1.0-MR1</jsr181-api.version>
-        <junit-toolbox.version>2.4</junit-toolbox.version>
+        <!-- ===== Kotlin ===== -->
         <kotlin.version>1.6.0</kotlin.version>
+
+        <!-- ===== Lettuce / Redis ===== -->
+        <lettuce.core.version>5.2.1.RELEASE</lettuce.core.version>
+
+        <!-- ===== Lombok ===== -->
         <lombok.version>1.18.26</lombok.version>
-        <org.hsqldb.version>2.7.1</org.hsqldb.version>
-        <poi.ooxml.version>5.2.2</poi.ooxml.version>
-        <random-beans.version>3.7.0</random-beans.version>
-        <rest.assured.version>4.4.0</rest.assured.version>
+
+        <!-- ===== Networking ===== -->
+        <netty.version>4.1.119.Final</netty.version>
+
+        <!-- ===== Utilities ===== -->
+        <camel.version>2.16.1</camel.version>
+        <cglib.version>3.3.0</cglib.version>
+        <generex.version>1.0.2</generex.version>
+        <github.lukehutch.fast-classpath-scanner.version>2.0.8</github.lukehutch.fast-classpath-scanner.version>
         <retry4j.version>0.7.1</retry4j.version>
         <sardine.version>5.7</sardine.version>
         <system.enterprise-id.version>0.0.3</system.enterprise-id.version>
+        <tomcat.version>8.0.21</tomcat.version>
+
+        <!-- ===== Weld ===== -->
+        <weld-core-version>3.1.9.Final</weld-core-version>
+        <weld-ee-version>1.0.0.CR8</weld-ee-version>
+
+        <!-- ===== Test dependencies ===== -->
+        <bean.matchers.version>0.10</bean.matchers.version>
+        <camunda.bpm.assert.version>2.0-alpha2</camunda.bpm.assert.version>
+        <camunda.junit5.version>1.1.0</camunda.junit5.version>
+        <dbunit.version>2.5.1</dbunit.version>
+        <domain.dsl.test.version>0.3.1</domain.dsl.test.version>
+        <greenmail.version>1.6.5</greenmail.version>
+        <hamcrest-date.version>2.0.4</hamcrest-date.version>
+        <hamcrest.optional.version>2.0</hamcrest.optional.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <jedis-mock.version>0.1.16</jedis-mock.version>
+        <junit-toolbox.version>2.4</junit-toolbox.version>
+        <maven.cucumber.reporting.plugin.version>2.0.0</maven.cucumber.reporting.plugin.version>
+        <mockftp.version>2.6</mockftp.version>
+        <net.trajano.commons.commons-testing.version>1.0.1</net.trajano.commons.commons-testing.version>
+        <org.hsqldb.version>2.7.1</org.hsqldb.version>
+        <org.xmlunit.version>2.6.3</org.xmlunit.version>
+        <random-beans.version>3.7.0</random-beans.version>
+        <rest.assured.version>4.4.0</rest.assured.version>
+        <selenium.version>2.46.0</selenium.version>
+        <wiremock.version>2.35.2</wiremock.version>
         <xmlunit.version>2.10.0</xmlunit.version>
     </properties>
 
@@ -144,6 +173,8 @@
     <!-- Default dependency management -->
     <dependencyManagement>
         <dependencies>
+
+            <!-- ===== BOM imports ===== -->
             <dependency>
                 <groupId>uk.gov.justice</groupId>
                 <artifactId>maven-common-bom</artifactId>
@@ -151,27 +182,7 @@
                 <scope>import</scope>
                 <version>${framework-comon-bom.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.docmosis</groupId>
-                <artifactId>docmosis</artifactId>
-                <version>${docmosis.version}</version>
-            </dependency>
-
-            <!-- Define the version of JBoss' Java EE 7 APIs we want to use -->
-            <!-- JBoss distributes a complete set of Java EE 7 APIs including a Bill
-                of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection)
-                of artifacts. We use this here so that we always get the correct versions
-                of artifacts. Here we use the jboss-javaee-7.0 stack (you can read this as
-                the JBoss stack of the Java EE 7 APIs). You can actually use this stack with
-                any version of WildFly that implements Java EE 7, not just WildFly 8! -->
-            <dependency>
-                <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-7.0</artifactId>
-                <version>${version.jboss.spec.javaee.7.0}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- this is controlling all netty dependencies instead of azure-core-http-netty, lettuce-core, etc. -->
+            <!-- controls all netty dependencies (azure-core-http-netty, lettuce-core, etc.) -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -180,48 +191,11 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- ===== Activiti ===== -->
             <dependency>
-                <groupId>org.jboss.arquillian.container</groupId>
-                <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
-                <version>${weld-ee-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver</artifactId>
-                <version>${mongodb-driver-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>${commons.text.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-dbutils</groupId>
-                <artifactId>commons-dbutils</artifactId>
-                <version>${commons-dbutils.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-core</artifactId>
-                <version>${weld-core-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.github.npathai</groupId>
-                <artifactId>hamcrest-optional</artifactId>
-                <version>${hamcrest.optional.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.exparity</groupId>
-                <artifactId>hamcrest-date</artifactId>
-                <version>${hamcrest-date.version}</version>
+                <groupId>org.activiti</groupId>
+                <artifactId>activiti-cdi</artifactId>
+                <version>${activiti.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.activiti</groupId>
@@ -230,65 +204,41 @@
             </dependency>
             <dependency>
                 <groupId>org.activiti</groupId>
-                <artifactId>activiti-cdi</artifactId>
-                <version>${activiti.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.activiti</groupId>
-                <artifactId>activiti-spring</artifactId>
-                <version>${activiti.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.activiti</groupId>
                 <artifactId>activiti-rest</artifactId>
                 <version>${activiti.version}</version>
                 <exclusions>
                     <exclusion>
-                        <!-- Excluded  OWASP security issue probably not needed, as we are not generating / using activiti diagrams -->
+                        <!-- OWASP: not needed as diagrams are not generated/used -->
                         <groupId>org.tinyjee.jgraphx</groupId>
                         <artifactId>jgraphx</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>javax.jms</groupId>
-                <artifactId>javax.jms-api</artifactId>
-                <version>${javax.jms.version}</version>
+                <groupId>org.activiti</groupId>
+                <artifactId>activiti-spring</artifactId>
+                <version>${activiti.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjrt</artifactId>
-                <version>${aspectj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.icegreen</groupId>
-                <artifactId>greenmail</artifactId>
-                <version>${greenmail.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.everit.json</groupId>
-                <artifactId>org.everit.json.schema</artifactId>
-                <version>${org.everit.json.schema.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
+
+            <!-- ===== Apache ActiveMQ (classic) ===== -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
                 <version>${activemq-client.version}</version>
             </dependency>
-
-            <!-- Apache Commons CSV - http://commons.apache.org/csv/ -->
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-csv</artifactId>
-                <version>${commons.csv.version}</version>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-ra</artifactId>
+                <version>${activemq-ra.version}</version>
+                <scope>provided</scope>
             </dependency>
 
-            <!-- Apache Commons Digester - http://commons.apache.org/digester/ -->
+            <!-- ===== Apache Commons ===== -->
+            <dependency>
+                <groupId>commons-dbutils</groupId>
+                <artifactId>commons-dbutils</artifactId>
+                <version>${commons-dbutils.version}</version>
+            </dependency>
             <dependency>
                 <groupId>commons-digester</groupId>
                 <artifactId>commons-digester</artifactId>
@@ -300,8 +250,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
-            <!-- Apache Commons Discovery - http://commons.apache.org/discovery/ -->
             <dependency>
                 <groupId>commons-discovery</groupId>
                 <artifactId>commons-discovery</artifactId>
@@ -313,65 +261,267 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons.fileupload.version}</version>
             </dependency>
-
-            <!-- Apache Commons net - http://commons.apache.org/net/ -->
             <dependency>
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
                 <version>${commons.net.version}</version>
             </dependency>
-
-            <!-- Apache Commons Lang - http://commons.apache.org/proper/commons-compress/ -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons.compress.version}</version>
             </dependency>
-
-            <!-- JavaBeans Activation Framework - http://www.oracle.com/technetwork/java/jaf11-139815.html -->
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${javax.activation.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-csv</artifactId>
+                <version>${commons.csv.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotation-api.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons.text.version}</version>
             </dependency>
 
+            <!-- ===== Apache CXF ===== -->
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${jaxb-runtime.version}</version>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-frontend-jaxws</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http-jetty</artifactId>
+                <version>${cxf.version}</version>
             </dependency>
 
-            <!-- Java Transaction API - http://java.sun.com/products/jta/ -->
+            <!-- ===== Apache PDFBox ===== -->
             <dependency>
-                <groupId>javax.transaction</groupId>
-                <artifactId>jta</artifactId>
-                <version>${javax.transaction.version}</version>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>fontbox</artifactId>
+                <version>${apache.pdfbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox</artifactId>
+                <version>${apache.pdfbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox-tools</artifactId>
+                <version>${apache.pdfbox.version}</version>
             </dependency>
 
-            <!-- JEE API - http://www.oracle.com/technetwork/java/javaee/overview/index.html -->
+            <!-- ===== Apache POI ===== -->
             <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>${poi.ooxml.version}</version>
+            </dependency>
+
+            <!-- ===== AspectJ ===== -->
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+
+            <!-- ===== Azure ===== -->
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-core</artifactId>
+                <version>${azure-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-jaxb-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-xml</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-data-appconfiguration</artifactId>
+                <version>${azure-data-appconfiguration.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-identity</artifactId>
+                <version>${azure-identity.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-storage-blob</artifactId>
+                <version>${azure-storage-blob.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-storage-file-datalake</artifactId>
+                <version>${azure-storage-file-datalake}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure.resourcemanager</groupId>
+                <artifactId>azure-resourcemanager</artifactId>
+                <version>${azure-resourcemanager.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-client-authentication</artifactId>
+                <version>${azure-client-authentication.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-eventgrid</artifactId>
+                <version>${azure-eventgrid.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-storage</artifactId>
+                <version>${azure-storage-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure.functions</groupId>
+                <artifactId>azure-functions-java-library</artifactId>
+                <version>${azure.functions.java.library.version}</version>
+            </dependency>
+
+            <!-- ===== Camunda ===== -->
+            <dependency>
+                <groupId>org.camunda.bpm</groupId>
+                <artifactId>camunda-engine</artifactId>
+                <version>${camunda.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.camunda.bpm.javaee</groupId>
+                <artifactId>camunda-ejb-client</artifactId>
+                <version>${camunda.version}</version>
+            </dependency>
+
+            <!-- ===== Database / Persistence ===== -->
+            <dependency>
+                <groupId>com.vladmihalcea</groupId>
+                <artifactId>hibernate-types-43</artifactId>
+                <version>${hibernate-types.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-c3p0</artifactId>
+                <version>${c3p0.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver</artifactId>
+                <version>${mongodb-driver-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz</artifactId>
+                <version>${quartz.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz-jobs</artifactId>
+                <version>${quartz.version}</version>
+            </dependency>
+
+            <!-- ===== Docmosis ===== -->
+            <dependency>
+                <groupId>com.docmosis</groupId>
+                <artifactId>docmosis</artifactId>
+                <version>${docmosis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>uk.gov.moj.cpp.docmosis</groupId>
+                <artifactId>docmosis-repackaging</artifactId>
+                <version>${docmosis.repackaging.version}</version>
+            </dependency>
+
+            <!-- ===== Document services ===== -->
+            <dependency>
+                <groupId>com.emc.documentum.fs</groupId>
+                <artifactId>darts-remote</artifactId>
+                <type>jar</type>
+                <version>${darts-remote.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.emc.documentum.fs</groupId>
+                <artifactId>dfs-remote</artifactId>
+                <version>${dfs-remote.version}</version>
+                <type>jar</type>
+            </dependency>
+
+            <!-- ===== Drools / Rules Engine ===== -->
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-commands</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-compiler</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-core</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-mvel</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-xml-support</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kie</groupId>
+                <artifactId>kie-api</artifactId>
+                <version>${drools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mvel</groupId>
+                <artifactId>mvel2</artifactId>
+                <version>${mvel2.version}</version>
+            </dependency>
+
+            <!-- ===== Elasticsearch ===== -->
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-high-level-client</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
+
+            <!-- ===== JAXB / XML / Web Services ===== -->
+            <dependency>
+                <!-- Legacy Java EE 8 API — pinned for Activiti 5.x compatibility -->
                 <groupId>javax</groupId>
                 <artifactId>javaee-api</artifactId>
-                <version>${javaee-api.version}</version>
+                <version>8.0.1</version>
             </dependency>
-
-
-            <!-- JSP API - http://www.oracle.com/technetwork/java/javaee/overview/index.html -->
             <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>jsp-api</artifactId>
-                <version>${jsp.version}</version>
+                <groupId>com.sun.istack</groupId>
+                <artifactId>istack-commons-runtime</artifactId>
+                <version>${istack-commons-runtime}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.messaging.saaj</groupId>
@@ -389,323 +539,60 @@
                 <artifactId>streambuffer</artifactId>
                 <version>${streambuffer.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-pool2</artifactId>
-                <version>${commons-pool2.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.github.lukehutch</groupId>
-                <artifactId>fast-classpath-scanner</artifactId>
-                <version>${github.lukehutch.fast-classpath-scanner.version}</version>
-            </dependency>
-
-            <!-- Test related -->
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-java</artifactId>
-                <version>${selenium.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.trajano.commons</groupId>
-                <artifactId>commons-testing</artifactId>
-                <version>${net.trajano.commons.commons-testing.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.vladmihalcea</groupId>
-                <artifactId>hibernate-types-43</artifactId>
-                <version>${hibernate-types.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-ra</artifactId>
-                <version>${activemq-ra.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!-- C3PO -->
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-c3p0</artifactId>
-                <version>${c3p0.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.quartz-scheduler</groupId>
-                <artifactId>quartz</artifactId>
-                <version>${quartz.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.quartz-scheduler</groupId>
-                <artifactId>quartz-jobs</artifactId>
-                <version>${quartz.version}</version>
-            </dependency>
-
-            <!-- JBoss Drools-->
-            <dependency>
-                <groupId>org.kie</groupId>
-                <artifactId>kie-api</artifactId>
-                <version>${drools.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.drools</groupId>
-                <artifactId>drools-mvel</artifactId>
-                <version>${drools.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.drools</groupId>
-                <artifactId>drools-core</artifactId>
-                <version>${drools.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.drools</groupId>
-                <artifactId>drools-compiler</artifactId>
-                <version>${drools.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvel</groupId>
-                <artifactId>mvel2</artifactId>
-                <version>${mvel2.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.mockftpserver</groupId>
-                <artifactId>MockFtpServer</artifactId>
-                <version>${mockftp.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.code.bean-matchers</groupId>
-                <artifactId>bean-matchers</artifactId>
-                <version>${bean.matchers.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>uk.gov.moj.cpp.docmosis</groupId>
-                <artifactId>docmosis-repackaging</artifactId>
-                <version>${docmosis.repackaging.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.liquibase</groupId>
-                <artifactId>liquibase-core</artifactId>
-                <version>${liquibase.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>pdfbox</artifactId>
-                <version>${apache.pdfbox.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>pdfbox-tools</artifactId>
-                <version>${apache.pdfbox.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>fontbox</artifactId>
-                <version>${apache.pdfbox.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.poi</groupId>
-                <artifactId>poi-ooxml</artifactId>
-                <version>${poi.ooxml.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>${javax.el-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.elasticsearch</groupId>
-                <artifactId>elasticsearch</artifactId>
-                <version>${elasticsearch.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>elasticsearch-rest-high-level-client</artifactId>
-                <version>${elasticsearch.version}</version>
-            </dependency>
-
-            <!-- Azure libraries -->
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-data-appconfiguration</artifactId>
-                <version>${azure-data-appconfiguration.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-identity</artifactId>
-                <version>${azure-identity.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-core</artifactId>
-                <version>${azure-core.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.module</groupId>
-                        <artifactId>jackson-module-jaxb-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-xml</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-client-authentication</artifactId>
-                <version>${azure-client-authentication.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-eventgrid</artifactId>
-                <version>${azure-eventgrid.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure.functions</groupId>
-                <artifactId>azure-functions-java-library</artifactId>
-                <version>${azure.functions.java.library.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-storage-file-datalake</artifactId>
-                <version>${azure-storage-file-datalake}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-storage-blob</artifactId>
-                <version>${azure-storage-blob.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.azure.resourcemanager</groupId>
-                <artifactId>azure-resourcemanager</artifactId>
-                <version>${azure-resourcemanager.version}</version>
-            </dependency>
-            <!-- Azure end -->
-
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda-time.version}</version>
-            </dependency>
-
-            <!-- TODO - move to GitHub -->
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxb-provider</artifactId>
-                <version>${jboss.resteasy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.camunda.bpm.extension</groupId>
-                <artifactId>camunda-bpm-junit5</artifactId>
-                <version>${camunda.junit5.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.camunda.bpm.javaee</groupId>
-                <artifactId>camunda-ejb-client</artifactId>
-                <version>${camunda.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.camunda.bpm</groupId>
-                <artifactId>camunda-engine</artifactId>
-                <version>${camunda.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.camunda.bpm.extension</groupId>
-                <artifactId>camunda-bpm-assert</artifactId>
-                <version>${camunda.bpm.assert.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib</artifactId>
-                <version>${cglib.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.emc.documentum.fs</groupId>
-                <artifactId>darts-remote</artifactId>
-                <type>jar</type>
-                <version>${darts-remote.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.emc.documentum.fs</groupId>
-                <artifactId>dfs-remote</artifactId>
-                <version>${dfs-remote.version}</version>
-                <type>jar</type>
-            </dependency>
-            <dependency>
-                <groupId>org.dbunit</groupId>
-                <artifactId>dbunit</artifactId>
-                <version>${dbunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hsqldb</groupId>
-                <artifactId>hsqldb</artifactId>
-                <version>${org.hsqldb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-runtime</artifactId>
-                <version>${istack-commons-runtime}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.jws</groupId>
-                <artifactId>javax.jws-api</artifactId>
-                <version>${javax.jws.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.ws</groupId>
-                <artifactId>jaxws-api</artifactId>
-                <version>${jaxws.api.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-rt</artifactId>
                 <version>${jaxws.rt.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.jws</groupId>
-                <artifactId>jsr181-api</artifactId>
-                <version>${jsr181-api.version}</version>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-runtime.version}</version>
             </dependency>
+
+            <!-- ===== JBoss / RESTEasy ===== -->
             <dependency>
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${jberet.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jackson2-provider</artifactId>
+                <version>${jboss.resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxb-provider</artifactId>
+                <version>${jboss.resteasy.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-client</artifactId>
                 <version>${jbossws.cxf.client.version}</version>
             </dependency>
+
+            <!-- ===== Joda Time ===== -->
             <dependency>
-                <groupId>com.github.fppt</groupId>
-                <artifactId>jedis-mock</artifactId>
-                <version>${jedis-mock.version}</version>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda-time.version}</version>
+            </dependency>
+
+            <!-- ===== JSON utilities ===== -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json-smart.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.googlecode.junit-toolbox</groupId>
-                <artifactId>junit-toolbox</artifactId>
-                <version>${junit-toolbox.version}</version>
-            </dependency>
+
+
+            <!-- ===== Kotlin ===== -->
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-reflect</artifactId>
@@ -716,30 +603,145 @@
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
+
+            <!-- ===== Lettuce / Redis ===== -->
+            <dependency>
+                <groupId>io.lettuce</groupId>
+                <artifactId>lettuce-core</artifactId>
+                <version>${lettuce.core.version}</version>
+            </dependency>
+
+            <!-- ===== Lombok ===== -->
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+
+            <!-- ===== Utilities ===== -->
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib</artifactId>
+                <version>${cglib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.evanlennick</groupId>
+                <artifactId>retry4j</artifactId>
+                <version>${retry4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.lookfirst</groupId>
+                <artifactId>sardine</artifactId>
+                <version>${sardine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.mifmif</groupId>
+                <artifactId>generex</artifactId>
+                <version>${generex.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.lukehutch</groupId>
+                <artifactId>fast-classpath-scanner</artifactId>
+                <version>${github.lukehutch.fast-classpath-scanner.version}</version>
+            </dependency>
+
+            <!-- ===== Weld ===== -->
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core</artifactId>
+                <version>${weld-core-version}</version>
+            </dependency>
+
+            <!-- ===== Test dependencies ===== -->
+            <dependency>
+                <groupId>com.github.fppt</groupId>
+                <artifactId>jedis-mock</artifactId>
+                <version>${jedis-mock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.npathai</groupId>
+                <artifactId>hamcrest-optional</artifactId>
+                <version>${hamcrest.optional.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.bean-matchers</groupId>
+                <artifactId>bean-matchers</artifactId>
+                <version>${bean.matchers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.junit-toolbox</groupId>
+                <artifactId>junit-toolbox</artifactId>
+                <version>${junit-toolbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.icegreen</groupId>
+                <artifactId>greenmail</artifactId>
+                <version>${greenmail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.benas</groupId>
+                <artifactId>random-beans</artifactId>
+                <version>${random-beans.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.trajano.commons</groupId>
+                <artifactId>commons-testing</artifactId>
+                <version>${net.trajano.commons.commons-testing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.camunda.bpm.extension</groupId>
+                <artifactId>camunda-bpm-assert</artifactId>
+                <version>${camunda.bpm.assert.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.camunda.bpm.extension</groupId>
+                <artifactId>camunda-bpm-junit5</artifactId>
+                <version>${camunda.junit5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dbunit</groupId>
+                <artifactId>dbunit</artifactId>
+                <version>${dbunit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.exparity</groupId>
+                <artifactId>hamcrest-date</artifactId>
+                <version>${hamcrest-date.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hsqldb</groupId>
+                <artifactId>hsqldb</artifactId>
+                <version>${org.hsqldb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
+                <version>${weld-ee-version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-test</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.lettuce</groupId>
-                <artifactId>lettuce-core</artifactId>
-                <version>${lettuce.core.version}</version>
+                <groupId>org.mockftpserver</groupId>
+                <artifactId>MockFtpServer</artifactId>
+                <version>${mockftp.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jackson2-provider</artifactId>
-                <version>${jboss.resteasy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.evanlennick</groupId>
-                <artifactId>retry4j</artifactId>
-                <version>${retry4j.version}</version>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-java</artifactId>
+                <version>${selenium.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>
@@ -748,39 +750,15 @@
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-placeholders</artifactId>
-                <version>${xmlunit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-matchers</artifactId>
                 <version>${xmlunit.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-rt-frontend-jaxws</artifactId>
-                <version>${cxf.version}</version>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-placeholders</artifactId>
+                <version>${xmlunit.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-rt-transports-http-jetty</artifactId>
-                <version>${cxf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.github.benas</groupId>
-                <artifactId>random-beans</artifactId>
-                <version>${random-beans.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.mifmif</groupId>
-                <artifactId>generex</artifactId>
-                <version>${generex.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.lookfirst</groupId>
-                <artifactId>sardine</artifactId>
-                <version>${sardine.version}</version>
-            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
Upgrades `cpp-platform-maven-common-bom` to Java 21 / WildFly 32 / Jakarta EE 10 as part of the Framework E (17.104.x) release line backport.

## Related
Framework E docs and status: https://github.com/hmcts/java-21-wildfly-32-updgrade-pilot-cpp-framework/blob/main/status/17.104.x-status.md