### PR TITLE
Upgrade to Java 25 / WildFly 40 (25.104.0-M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [25.104.0-M1] - 2026-06-10
+### Changed
+- Updated parent `cpp-platform-maven-parent-pom` to `25.104.0-M1`
+- Updated imported `cp-maven-common-bom` (`framework-comon-bom.version`) to `25.104.0-M3`
+
 ## [17.104.0] - 2025-12-16
 ### Changed
 - Enable gitleaks PR scan

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:common-bom"

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <artifactId>common-bom</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CPP Common BOM</name>
     <description>Common bill of materials defining standard versions for dependencies</description>
@@ -29,7 +29,7 @@
             Imported here to avoid duplication of library versions.
             File can be found here: https://github.com/hmcts/cp-maven-common-bom
         -->
-        <framework-comon-bom.version>21.0.0-M1-SNAPSHOT</framework-comon-bom.version>
+        <framework-comon-bom.version>25.104.0-M3</framework-comon-bom.version>
 
         <!-- ===== Activiti ===== -->
         <activiti.version>5.22.0</activiti.version>


### PR DESCRIPTION
## Summary
- Updated parent `cpp-platform-maven-parent-pom` to `25.104.0-M1`
- Updated `framework-comon-bom.version` (`cp-maven-common-bom`) to `25.104.0-M3`

## Test plan
- [ ] CI passes
- [ ] Merge and trigger Azure release pipeline manually (`RUN_RELEASE=true`)
- [ ] Confirm `cpp-platform-maven-common-bom:25.104.0-M1` in Artifactory