### PR TITLE
Add HikariCP to platform BOM and override JaCoCo for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
             File can be found here: https://github.com/hmcts/cp-maven-common-bom
         -->
         <framework-comon-bom.version>25.104.0-M3</framework-comon-bom.version>
+        <!-- 0.8.12 (parent-pom M1) cannot instrument Java 25 class files (major version 69); override until parent-pom M2 -->
+        <plugins.jacoco.version>0.8.14</plugins.jacoco.version>
 
         <!-- ===== Activiti ===== -->
         <activiti.version>5.22.0</activiti.version>
@@ -78,6 +80,7 @@
 
         <!-- ===== Database / Persistence ===== -->
         <c3p0.version>4.1.6.Final</c3p0.version>
+        <hikari.version>6.2.1</hikari.version>
         <hibernate-types.version>2.20.0</hibernate-types.version>
         <mongodb-driver-version>3.0.2</mongodb-driver-version>
         <quartz.version>2.5.0</quartz.version>
@@ -410,6 +413,11 @@
             </dependency>
 
             <!-- ===== Database / Persistence ===== -->
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>${hikari.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.vladmihalcea</groupId>
                 <artifactId>hibernate-types-43</artifactId>


### PR DESCRIPTION
## Summary

- Adds `HikariCP 6.2.1` to the managed dependencies so individual context root poms no longer need to declare the version locally
- Overrides `plugins.jacoco.version` to `0.8.14` — JaCoCo 0.8.12 (inherited from `parent-pom M1`) cannot instrument Java 25 class files (major version 69); this override stays until `parent-pom M2` is released with 0.8.14

## Context

Part of the 25.104.x Java 25 / WildFly 40 upgrade release chain. `HikariCP` was identified in `cpp-context-users-groups` root pom as a stray version that belongs in the BOM.

## Test plan

- [ ] CI passes
- [ ] After merging as M2, `cpp-context-users-groups` builds without `hikari.version` in its root pom

🤖 Generated with [Claude Code](https://claude.com/claude-code)